### PR TITLE
Added option argument to listAllSubscribesToCampaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following methods are currently available on the client instance. You can fi
 | Fetch a campaign                     | `client.fetchCampaign(campaignId, callback)`                                 |
 | Activate a campaign                  | `client.activateCampaign(campaignId, callback)`                              |
 | Pause a campaign                     | `client.pauseCampaign(campaignId, callback)`                                 |
-| List specific campaign's subscribers | `client.listAllSubscribesToCampaign(campaignId, callback)`                   |
+| List specific campaign's subscribers | `client.listAllSubscribesToCampaign(campaignId, options = {}, callback)`                   |
 | Subscribe to a campaign              | `client.subscribeToCampaign(campaignId, payload, callback)`                  |
 
 ### Campaign subscriptions

--- a/lib/campaigns.js
+++ b/lib/campaigns.js
@@ -44,11 +44,12 @@ module.exports = {
    * List all subscribers subscribed to a campaign
    *
    * @param {object} campaignId - Required. The campaign id
+   * @param {object} options - An object with status and sort details
    * @param {callback} callback - An optional callback
    * @returns {promise}
    */
-  listAllSubscribesToCampaign(campaignId, callback) {
-    return this.get(`v2/${this.accountId}/campaigns/${campaignId}/subscribers`, {}, callback);
+  listAllSubscribesToCampaign(campaignId, options = {}, callback) {
+    return this.get(`v2/${this.accountId}/campaigns/${campaignId}/subscribers`, { qs: options }, callback);
   },
   /**
    * Subscribe someone to a campaign

--- a/spec/lib/campaigns_spec.js
+++ b/spec/lib/campaigns_spec.js
@@ -56,7 +56,17 @@ describe('Campaigns with callback', () => {
   it('should list all subscribers to a campaign and call request with get', (done) => {
     expect(typeof client.listAllSubscribesToCampaign).toEqual('function');
 
-    client.listAllSubscribesToCampaign(campaignId, (error, response) => {
+    client.listAllSubscribesToCampaign(campaignId, {}, (error, response) => {
+      expect(response.statusCode).toBe(200);
+      expect(client.request.callCount).toBe(1);
+    });
+    done();
+  });
+
+  it('should list all active subscribers to a campaign and call request with get', (done) => {
+    expect(typeof client.listAllSubscribesToCampaign).toEqual('function');
+
+    client.listAllSubscribesToCampaign(campaignId, { status: 'active' }, (error, response) => {
       expect(response.statusCode).toBe(200);
       expect(client.request.callCount).toBe(1);
     });
@@ -155,7 +165,7 @@ describe('Campaigns with Promise', () => {
   it('should list all subscribers to a campaign', (done) => {
     expect(typeof client.listAllSubscribesToCampaign).toEqual('function');
 
-    client.listAllSubscribesToCampaign(campaignId)
+    client.listAllSubscribesToCampaign(campaignId, {})
       .then((response) => {
         expect(response.statusCode).toBe(200);
         expect(client.request.callCount).toBe(1);
@@ -163,7 +173,21 @@ describe('Campaigns with Promise', () => {
       .catch(failTest);
     done();
 
-    expect(client.get).toHaveBeenCalledWith('v2/9999999/campaigns/4444444/subscribers', {}, undefined);
+    expect(client.get).toHaveBeenCalledWith('v2/9999999/campaigns/4444444/subscribers', { qs: {} }, undefined);
+  });
+
+  it('should list all active subscribers to a campaign', (done) => {
+    expect(typeof client.listAllSubscribesToCampaign).toEqual('function');
+
+    client.listAllSubscribesToCampaign(campaignId, { status: 'active' })
+      .then((response) => {
+        expect(response.statusCode).toBe(200);
+        expect(client.request.callCount).toBe(1);
+      })
+      .catch(failTest);
+    done();
+
+    expect(client.get).toHaveBeenCalledWith('v2/9999999/campaigns/4444444/subscribers', { qs: { status: 'active' } }, undefined);
   });
 
   it('should list all subscribers to a campaign', (done) => {


### PR DESCRIPTION
added feature to query listAllSubscribesToCampaign using following arguments:

status | Optional. The status to filter by: active, unsubscribed, or removed. Defaults to active.
page | Optional. The page number. Defaults to 1.
sort | Optional. The attribute by which to sort the results: id or created_at. Defaults to created_at.
direction | Optional. The direction to sort the results: asc or desc. Defaults to desc.
per_page | Optional. The number of records to be returned on each page. Defaults to 100. Maximum 1000.

https://developer.drip.com/?javascript#list-all-subscribers-subscribed-to-a-campaign